### PR TITLE
Updated dependencies and remove deprecated code

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "proxy": "http://localhost:8080",
   "dependencies": {
-    "axios": "^0.25.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-router-dom": "^5.0.0",
-    "react-scripts": "^5.0.0",
-    "web-vitals": "^2.1.3"
+    "axios": "^1.3.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.8.1 ",
+    "react-scripts": "^5.0.1",
+    "web-vitals": "^3.1.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,12 +1,9 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById('root')
-);
+const container = document.getElementById("root");
+const root = ReactDOM.createRoot(container);
+root.render(<App />);
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.19.0",
-    "dotenv": "^14.2.0",
+    "dotenv": "^16.0.3",
     "express": "^4.17.1",
-    "mongoose": "^6.1.7"
+    "mongoose": "^6.9.2"
   },
   "devDependencies": {
     "concurrently": "^7.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,7 @@ const app = express();
 
 // This is where your API is making its initial connection to the database
 mongoose.Promise = global.Promise;
+mongoose.set("strictQuery", false);
 mongoose.connect(process.env.DATABASE_CONNECTION_STRING, {
   useNewUrlParser: true,
 });


### PR DESCRIPTION
This project has been update to use:

- React 18
- Latest version of Create React App
- and more

It's now supported by Node 16 and 18

When starting your dev environment you will see a deprecation warning for Webpack. I was unable to find a fix that doesn't require manual changes to be made by students. The fault lies with the Create React App maintainers.

[There's an open issue with Create React App to fix the deprecation warning](https://github.com/facebook/create-react-app/issues/12035)